### PR TITLE
Auto guess doesn't work when the original request has query part.

### DIFF
--- a/lib/Plack/Middleware/Proxy/RewriteLocation.pm
+++ b/lib/Plack/Middleware/Proxy/RewriteLocation.pm
@@ -63,7 +63,9 @@ sub call {
                 } else {
                     # Auto-guessing url_map
                     my $original_url = "$env->{'psgi.url_scheme'}://" . 
-                                       "$env->{HTTP_HOST}$env->{REQUEST_URI}";
+                                       $env->{HTTP_HOST} .
+                                       $env->{SCRIPT_PATH} .
+                                       $env->{PATH_INFO};
                     $original_url .= '?' . $env->{QUERY_STRING}
                         if defined $env->{QUERY_STRING} && $env->{QUERY_STRING};
                     @map = _different_part(

--- a/t/middleware/rewrite-auto_guess.t
+++ b/t/middleware/rewrite-auto_guess.t
@@ -44,7 +44,11 @@ sub test_rewriting_path($$$) {
         client => sub {
             my $cb = shift;
 
-            my $res = $cb->(GET "http://localhost$from/redirect");
+            my $url = "http://localhost$from/redirect";
+            # Guess correctly even if the original request contains query
+            $url .= $1 if $redirect_to =~ /(\?.+$)/;
+            my $res = $cb->(GET $url);
+
             is $res->code, 301, 'got right status to redirect';
             like $res->header('Location'), 
                  qr!^http://[^/]+\Q$from$redirect_to\E$!,


### PR DESCRIPTION
Since REQUEST_URI contains QUERY_STRING, query part is duplicated.

It's all my fault :(
