### PR TITLE
Better cookie support with the AnyEvent::HTTP backend

### DIFF
--- a/lib/Plack/App/Proxy/Backend/AnyEvent/HTTP.pm
+++ b/lib/Plack/App/Proxy/Backend/AnyEvent/HTTP.pm
@@ -32,6 +32,12 @@ sub call {
                       map { $_ => $headers->{$_} } grep {! /^[A-Z]/} keys %$headers
                     );
 
+                    my $cookies = $http_headers->header( 'Set-Cookie' );
+                    if ( $cookies ) {
+                        my @cookies = split /,(?=\S+)/, $cookies;
+                        $http_headers->header( Set_Cookie => \@cookies );
+                    }
+
                     $writer = $respond->([
                         $headers->{Status},
                         [$self->response_headers->($http_headers)],


### PR DESCRIPTION
AnyEvent::HTTP will munge HTTP headers with the same name into a
single one, thus destroying Set-Cookie headers if more than one
cookie is set. This patch provides a primitive fix and a couple of
tests.
