### PR TITLE
Avoid global performance penalty by using $&

### DIFF
--- a/lib/Plack/Middleware/Proxy/RewriteLocation.pm
+++ b/lib/Plack/Middleware/Proxy/RewriteLocation.pm
@@ -9,8 +9,8 @@ use URI;
 sub _different_part($$) {
     my ($from, $to) = @_;
 
-    while ($from =~ m{[^/]+(?:\://$|/$|$)}g) {
-        my $last_part = $&;
+    while ($from =~ m{([^/]+(?:\://$|/$|$))}g) {
+        my $last_part = $1;
         last unless $to =~ /\Q$last_part\E$/;
 
         $from =~ s!\Q$last_part\E$!!;


### PR DESCRIPTION
We shouldn't use $& in our codes.

http://perldoc.perl.org/perlvar.html

> The use of this variable anywhere in a program imposes a considerable performance penalty on all regular expression matches.
