### PR TITLE
New middleware for CONNECT methods without external dependecies

### DIFF
--- a/lib/Plack/Middleware/Proxy/Connect/IO.pm
+++ b/lib/Plack/Middleware/Proxy/Connect/IO.pm
@@ -1,0 +1,116 @@
+package Plack::Middleware::Proxy::Connect::IO;
+
+use 5.006;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.0100';
+
+use parent qw(Plack::Middleware);
+
+use IO::Socket::INET;
+use IO::Select;
+
+use constant CHUNKSIZE => 64 * 1024;
+
+sub call {
+    my ($self, $env) = @_;
+
+    return $self->app->($env) unless $env->{REQUEST_METHOD} eq 'CONNECT';
+
+    my $client = $env->{'psgix.io'}
+        or return [501, [], ['Not implemented CONNECT method']];
+
+    my ($host, $port) = $env->{REQUEST_URI} =~ m{^(?:.+\@)?(.+?)(?::(\d+))?$};
+
+    my $ioset = IO::Select->new;
+
+    sub {
+        my ($respond) = @_;
+
+        my $remote = IO::Socket::INET->new(
+            PeerAddr => $host,
+            PeerPort => $port
+        ) or return $respond->([502, [], ['Bad Gateway']]);
+
+        my $writer = $respond->([200, []]);
+
+        $ioset->add($client);
+        $ioset->add($remote);
+
+        while (1) {
+            for my $socket ($ioset->can_read) {
+                my $buffer;
+
+                my $socket2 = do {
+                    if ($socket == $remote) {
+                        $client;
+                    } elsif ($socket == $client) {
+                        $remote;
+                    }
+                } or return $respond->([502, [], ['Bad Gateway']]);
+
+                my $read = $socket->sysread($buffer, CHUNKSIZE);
+
+                if ($read) {
+                    $socket2->syswrite($buffer);
+                } else {
+                    $remote->close;
+                    $client->close;
+                    return;
+                }
+            }
+        }
+
+    };
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Plack::Middleware::Proxy::Connect::IO - CONNECT method without dependencies
+
+=head1 SYNOPSIS
+
+  use Plack::Builder;
+  use Plack::App::Proxy;
+
+  builder {
+      enable "Proxy::Connect::IO";
+      enable sub {
+          my $app = shift;
+          return sub {
+              my $env = shift;
+              ($env->{'plack.proxy.url'} = $env->{REQUEST_URI}) =~ s|^/||;
+              $app->( $env );
+          };
+      };
+      Plack::App::Proxy->new->to_app;
+  };
+
+=head1 DESCRIPTION
+
+This middleware handles the C<CONNECT> method. It allows to connect to
+C<https> addresses.
+
+The middleware runs on servers supporting C<psgix.io> and provides own
+event loop so does not work correctly with C<psgi.nonblocking> servers.
+
+The middleware uses only Perl's core
+modules: L<IO::Socket::INET> and L<IO::Select>.
+
+=head1 AUTHOR
+
+Piotr Roszatycki E<lt>dexter@cpan.orgE<gt>
+
+Masahiro Honma E<lt>hiratara@cpan.orgE<gt>
+
+=head1 SEE ALSO
+
+L<Plack::App::Proxy>
+
+=cut

--- a/t/middleware/connect_io.t
+++ b/t/middleware/connect_io.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::TCP;
+use IO::Socket::INET;
+use Plack::Loader;
+use Plack::Middleware::Proxy::Connect::IO;
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "perl crashes on Win32";
+}
+
+test_tcp(
+    client => sub {
+        my $port_proxy = shift;
+        test_tcp(
+            client => sub {
+                my $port_orig = shift;
+                my $sock = IO::Socket::INET->new(
+                    PeerPort => $port_proxy,
+                    PeerAddr => '127.0.0.1',
+                    Proto    => 'tcp',
+                ) or die $!;
+
+                # Perform the handshake.
+                print $sock "CONNECT 127.0.0.1:$port_orig HTTP/1.0\015\012", 
+                            "\015\012";
+                like scalar <$sock>, qr(^HTTP/1\.[01] 2\d\d );
+                while(<$sock>){ /^\015\012$/ and last; }  # skip headers
+
+                # Send ping to the original server.
+                print $sock "PING\015\012";
+                is scalar <$sock>, "PONG\015\012";
+
+                $sock->close;
+            },
+            server => sub {
+                my $port_orig = shift;
+
+                # Run a ping-pong server.
+                my $sock = IO::Socket::INET->new(
+                    LocalPort => $port_orig,
+                    LocalAddr => '127.0.0.1',
+                    Proto     => 'tcp',
+                    Listen    => 1,
+                    (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
+                ) or die $!;
+
+                while(my $remote = $sock->accept){
+                    if(scalar <$remote> =~ /^PING/){
+                        print $remote "PONG\015\012";
+                    }
+                };
+            },
+        );
+    },
+    server => sub {
+        my $port = shift;
+        my $server = Plack::Loader->auto( port => $port, host => '127.0.0.1' );
+        $server->run(
+           Plack::Middleware::Proxy::Connect::IO->wrap(
+                sub { [200, ['Content-Type' => 'plain/text'], ['Hi']] }
+           )
+        );
+    },
+);
+
+done_testing;
+


### PR DESCRIPTION
This is middleware for CONNECT method which implements own event-loop and doesn't use AnyEvent, so can be used ie. in FatPacked Perl scripts.
