### PR TITLE
Use warnings in all modules.

### DIFF
--- a/lib/Plack/App/Proxy.pm
+++ b/lib/Plack/App/Proxy.pm
@@ -1,6 +1,7 @@
 package Plack::App::Proxy;
 
 use strict;
+use warnings;
 use 5.008_001;
 use parent 'Plack::Component';
 use Plack::Util::Accessor qw/remote preserve_host_header backend options/;

--- a/lib/Plack/App/Proxy/Backend.pm
+++ b/lib/Plack/App/Proxy/Backend.pm
@@ -1,6 +1,7 @@
 package Plack::App::Proxy::Backend;
 
 use strict;
+use warnings;
 use parent 'Plack::Component';
 use Plack::Util::Accessor qw/url req headers method content response_headers options/;
 

--- a/lib/Plack/App/Proxy/Backend/AnyEvent/HTTP.pm
+++ b/lib/Plack/App/Proxy/Backend/AnyEvent/HTTP.pm
@@ -1,6 +1,7 @@
 package Plack::App::Proxy::Backend::AnyEvent::HTTP;
 
 use strict;
+use warnings;
 use parent 'Plack::App::Proxy::Backend';
 use AnyEvent::HTTP;
 

--- a/lib/Plack/App/Proxy/Backend/LWP.pm
+++ b/lib/Plack/App/Proxy/Backend/LWP.pm
@@ -1,6 +1,7 @@
 package Plack::App::Proxy::Backend::LWP;
 
 use strict;
+use warnings;
 use parent 'Plack::App::Proxy::Backend';
 use LWP::UserAgent;
 

--- a/lib/Plack/Middleware/Proxy/AddVia.pm
+++ b/lib/Plack/Middleware/Proxy/AddVia.pm
@@ -1,5 +1,6 @@
 package Plack::Middleware::Proxy::AddVia;
 use strict;
+use warnings;
 use parent 'Plack::Middleware';
 
 use Plack::Util;

--- a/lib/Plack/Middleware/Proxy/RewriteLocation.pm
+++ b/lib/Plack/Middleware/Proxy/RewriteLocation.pm
@@ -1,5 +1,6 @@
 package Plack::Middleware::Proxy::RewriteLocation;
 use strict;
+use warnings;
 use parent 'Plack::Middleware';
 
 use Plack::Util;


### PR DESCRIPTION
Following the model of most of the Plack apps and midlewares, using strict and warnings in all .pm files.
